### PR TITLE
Correção de link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 🔖 https://flexboxfroggy.com <br>
 🔖 https://flexboxdefense.com <br>
 🔖 https://100dayscss.com <br>
-🔖 https://cssbatle.dev <br>
+🔖 https://cssbattle.dev <br>
 🔖 https://css-tricks.com/guides/ <br>
 🔖 https://csshell.dev/ (Coleção de erros comuns de CSS e como corrigi-los) <br>
 


### PR DESCRIPTION
Na seção 'Sites para aprender ou treinar CSS' faltava um 't' no link 'https://cssbatle.dev'