### PR TITLE
Adicionar hyperlinks na seção de ferramentas

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,14 +135,14 @@
 
 ## 📚 7 FERRAMENTAS PARA QUE TODO DEV PRECISA CONHECER:
 
-🔖 Figma: ferramenta para design de interfaces. <br>
-🔖 Insomnia: é um API Client, uma ferramenta para fazer testes de API's. <br>
-🔖 Rive: ferramenta colaborativa de animação para apps, jogos e sites. <br>
-🔖 CloudCraft: plataforma com foco em criar desenhos de arquiteturas AWS. <br>
-🔖 BundlePhobia: site para descobrir o custo de adicionar um npm package no seu pacote. <br>
-🔖 Font Flipper: Tinder das fontes, basta apertar X caso não goste e ❤ se você gostar, adicione aos favoritos já com o nome da fonte e faça o download pelo Google fonts. <br>
-🔖 VisBug: é uma extensão de Chrome, criada pelo google, ferramenta de design que te permite mudar o layout das páginas da web desde o estilo de fontes até a posição dos elementos. <br>
-🔖 ThunderClient: é um Rest API Client totalmente leve e compatível com Visual Studio Code. Idêntico ao Postman, ele serve para realizar testes com nossas requisções HTTP. <br>
+🔖 [Figma](https://www.figma.com): ferramenta para design de interfaces. <br>
+🔖 [Insomnia](https://insomnia.rest): é um API Client, uma ferramenta para fazer testes de API's. <br>
+🔖 [Rive](https://rive.app): ferramenta colaborativa de animação para apps, jogos e sites. <br>
+🔖 [CloudCraft](https://www.cloudcraft.co): plataforma com foco em criar desenhos de arquiteturas AWS. <br>
+🔖 [BundlePhobia](https://bundlephobia.com): site para descobrir o custo de adicionar um npm package no seu pacote. <br>
+🔖 [Font Flipper](https://fontflipper.com): Tinder das fontes, basta apertar X caso não goste e ❤ se você gostar, adicione aos favoritos já com o nome da fonte e faça o download pelo Google fonts. <br>
+🔖 [VisBug](https://github.com/GoogleChromeLabs/ProjectVisBug): é uma extensão de Chrome, criada pelo google, ferramenta de design que te permite mudar o layout das páginas da web desde o estilo de fontes até a posição dos elementos. <br>
+🔖 [ThunderClient](https://www.thunderclient.io): é um Rest API Client totalmente leve e compatível com Visual Studio Code. Idêntico ao Postman, ele serve para realizar testes com nossas requisções HTTP. <br>
 
 ## 📚 SITES PARA PRATICAR UI/UX:
 


### PR DESCRIPTION
Adicionei os links direto nos nomes das ferramentas pra facilitar o acesso de quem está navegando pelo repositório sem quebrar a organização atual do texto.