### PR TITLE
Replace caiuse.com with caniuse.com + Grammar Fixes + Coodesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@
 🔖 https://bergamot.io <br>
 🔖 https://justremote.co <br>
 🔖 https://workingnomads.co <br>
+🔖 https://coodesh.com/ <br>
 
 ## 📚 ÓTIMOS SITES PARA DESENVOLVEDORES:
 


### PR DESCRIPTION
Eu acredito que o site correto seja "caniuse.com" e não caiuse.com...

Realizado correção gramatical na parte de comandos do git
Adicionado Coodesh na lista de sites para vagas remotas