### PR TITLE
fixing mispelling in readme change desenvoldor to desenvolvedor

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## :dart: O guia para alavancar a sua carreira
 
-Abaixo você encontrará conteúdos para te guiar e ajudar a se torna um desenvolvedor ou qualquer área de TI, caso você já atue como desenvoldor ou em outra área confere o repositórios para descobrir novas ferramentas para o seu dia-a-dia, os caminhos que você pode tomar e as tecnologias para incorporar na sua stack para se tornar um profissional atualizado e diferenciado em frontend, back-end, entre outras, faça bom uso do guia e bons estudos!
+Abaixo você encontrará conteúdos para te guiar e ajudar a se torna um desenvolvedor ou qualquer área de TI, caso você já atue como desenvolvedor ou em outra área confere o repositórios para descobrir novas ferramentas para o seu dia-a-dia, os caminhos que você pode tomar e as tecnologias para incorporar na sua stack para se tornar um profissional atualizado e diferenciado em frontend, back-end, entre outras, faça bom uso do guia e bons estudos!
 
 <sub> <strong>Segue nas redes sociais para acompanhar mais conteúdo: </strong> <br>
 [<img src = "https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white">](https://github.com/arthurspk)


### PR DESCRIPTION
Corrigindo um pequeno erro no README, a palavra "desenvolvedor" estava escrita como "desenvoldor".