### PR TITLE
Adicionado novo site com vagas remotas.

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Abaixo você encontrará conteúdos para te guiar e ajudar a se tornar um desenv
 - [Há Vagas](https://havagas.pt) <br>
 - [Hired](https://hired.com) <br>
 - [JustRemote](https://justremote.co) <br>
+- [Remotar](https://remotar.com.br) <br>
 - [Remote OK](https://remoteok.io) <br>
 - [Strider](https://www.onstrider.com/) <br>
 - [Toptal](https://www.toptal.com) <br>


### PR DESCRIPTION
Foi adicionado o site do Remotar (https://remotar.com.br) na lista de sites para vagas remotas, é um site com uma das melhores curodorias de vagas remotas.