### PR TITLE
Add UBL na lista "Sites para estudar programação"

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@
 - [Kaggle](https://www.kaggle.com/learn) - Site com diversos cursos gratuitos de Python & DataScience (EN)
 - [Complete Intro to Web Development](https://btholt.github.io/intro-to-web-dev-v2/) - Site com os principais conteúdos referentes a desenvolvimento web criado e mantido por um dos professores do site Frontend Masters (EN)
 - [4noobs](https://github.com/he4rt/4noobs) - Repositório desenvolvido para mostrar os conhecimentos básicos em diversas linguagens e ferramentas para desenvolvedores iniciantes.
+- [Universidade Brasileira Livre - Ciência da Computação](https://github.com/Universidade-Livre/ciencia-da-computacao) - Repositório com conteúdos gratuitos da grade Ciência da Computação organizados para estudo, também com Comunidade no Discord para que os estudantes possam se ajudar e tirar dúvidas.
 
 ## 🎨 Sites para desenvolvedor front-end
 


### PR DESCRIPTION
A [Universidade Brasileira Livre](https://ulivre.dev/) é uma comunidade e organização voltada para a divulgação e organização do conteúdo gratuito dos tópicos de Ciência da Computação (CC) em Português. Além do repositório, há também a Comunidade para apoiar as pessoas que estão estudando pelos materiais.